### PR TITLE
add eval_all.py

### DIFF
--- a/evaluation/KW_IND_diff.py
+++ b/evaluation/KW_IND_diff.py
@@ -243,6 +243,52 @@ def compute_kw_table(csv_path: str,
     out = out.sort_values("metric", kind="mergesort").reset_index(drop=True)
     return out
 
+def eval(path_to_csv1, path_to_csv2, print_details=False):
+    # fix optional hyperparameters with their default values
+    age_col = TARGET_DEFAULT
+    metrics = ",".join(METRICS_DEFAULT)
+    custom_bins = ""
+    min_per_group = 2
+    p_norm = DEFAULT_P_NORM
+    p_scale = DEFAULT_P_SCALE
+    p_cap = DEFAULT_P_CAP
+
+    t1 = compute_kw_table(
+        path_to_csv1, age_col, metrics, custom_bins,
+        min_per_group, p_norm, p_scale, p_cap
+    )
+    t2 = compute_kw_table(
+        path_to_csv2, age_col, metrics, custom_bins,
+        min_per_group, p_norm, p_scale, p_cap
+    )
+
+    # metric の和集合で揃え、欠側は0埋め
+    metrics_all = sorted(set(t1["metric"]).union(set(t2["metric"])))
+    t1i = t1.set_index("metric").reindex(metrics_all).fillna(0.0)
+    t2i = t2.set_index("metric").reindex(metrics_all).fillna(0.0)
+
+    # 差分 (file2 - file1)
+    diff = (t2i[NUM_COLS] - t1i[NUM_COLS]).reset_index()
+    diff = diff.rename(columns={"index": "metric"}).sort_values("metric", kind="mergesort").reset_index(drop=True)
+
+    # 表示（KW_IND 風ヘッダ、group_sizes なし）
+    if print_details:
+        with pd.option_context("display.max_columns", None,
+                               "display.width", None,
+                               "display.float_format", lambda x: f"{x:.6g}"):
+            print("\n=== KW_IND Diff (file2 - file1) — H_norm / p_norm / effect sizes (0–1) ===")
+            print(diff.to_string(index=False))
+
+    # 全差分の最大絶対値
+    max_abs = float(np.nanmax(np.abs(diff[NUM_COLS].to_numpy()))) if not diff.empty else 0.0
+    if print_details:
+        print(f"\nMAX_ABS_DIFF {max_abs:.6g}")
+
+    # 保存オプション
+    # if args.out:
+    #     diff.to_csv(args.out, index=False)
+
+    return max_abs
 
 def main():
     ap = argparse.ArgumentParser(description="KW_IND 差分: 2つのCSVの 0～1 指標を (file2 - file1) で出力し、最後に最大絶対差を表示（group_sizes非表示）。")

--- a/evaluation/eval_all.py
+++ b/evaluation/eval_all.py
@@ -1,0 +1,31 @@
+import argparse
+
+import pandas as pd
+
+import stats_diff
+import LR_asthma_diff
+import KW_IND_diff
+
+if __name__ == "__main__":
+    ap = argparse.ArgumentParser(description="")
+    ap.add_argument("Bi_csv", help="path to Bi.csv")
+    ap.add_argument("Ci_csv", help="path to Ci.csv")
+    # ap.add_argument("-o", "--out", default=None, help="optional path to save the full diff table (CSV)")
+    ap.add_argument("-d", "--detail", action="store_true", help="[optional] despley the details")
+    args = ap.parse_args()
+
+    # 基本統計の誤差を算出
+    stats_diff_max_abs = stats_diff.eval(args.Bi_csv, args.Ci_csv, args.detail)
+    print(f"stats_diff max_abs: {stats_diff_max_abs}")
+
+    # Logistic Regressionでの誤差を算出
+    LR_asthma_diff_max_abs = LR_asthma_diff.eval(args.Bi_csv, args.Ci_csv, args.detail)
+    print(f"LR_asthma_diff max_abs: {LR_asthma_diff_max_abs}")
+    
+    # KW_IND_diff
+    KW_IND_diff_max_abs = KW_IND_diff.eval(args.Bi_csv, args.Ci_csv, args.detail)
+    print(f"KW_IND_diff max_abs: {KW_IND_diff_max_abs}")
+
+    # 重み付き合計
+    total = 40 * stats_diff_max_abs + 20 * LR_asthma_diff_max_abs + 20 * KW_IND_diff_max_abs
+    print(f"Total loss: {total}")


### PR DESCRIPTION
evaluation内の3つの評価コード(stats_diff.py, LR_asthma_diff.py, KW_IND_diff.py)を一括で実行するeval_all.pyを追加
↓入出力例
```
$ python evaluation/eval_all.py data/HI_10K.csv data/MA_10K.csv
stats_diff max_abs: 0.5518
LR_asthma_diff max_abs: 0.8862336002175595
KW_IND_diff max_abs: 0.033761053244578954
Total loss: 40.471893069242775
```
Total lossは議事録に合わせて、それぞれx40, x20, x20した。

-dを指定すると途中のログを省略せずに出力。3つの評価コードでのoptionコマンド引数はout以外はdefault値で固定。結果の書き出し(out)には非対応。

この機能を実現するために、stats_diff.py, LR_asthma_diff.py, KW_IND_diff.pyにeval(path_to_csv1, path_to_csv2, print_details=False)という共通のインターフェースを持つ関数を追記。有用性を使って逐次的に加工データを更新するアルゴリゴリズムの実装に活用する場合も想定して、返り値をabs_maxに統一。各ファイルのmain()を一部だけ変更して実装。