### PR TITLE
Removed some redundant functions from evaluation modules and defined some wrappers

### DIFF
--- a/evaluation/KW_IND_diff.py
+++ b/evaluation/KW_IND_diff.py
@@ -13,238 +13,140 @@ KW_IND_diff.py
 """
 
 import argparse
+import sys
+import os
+
 import numpy as np
 import pandas as pd
-from scipy.stats import kruskal, chi2, norm
+
+# モジュールの相対参照制限を強制的に回避
+current_dir = os.path.dirname(os.path.abspath(__file__))
+sys.path.append(os.path.join(current_dir, '..', 'analysis'))
+import KW_IND
 
 # ==== 既定値（KW_IND.py と同じ） ====
-TARGET_DEFAULT = "AGE"
-DEFAULT_BINS = [0, 18, 45, 65, 75, 200]
-METRICS_DEFAULT = [
-    "encounter_count",
-    "num_medications",
-    "num_procedures",
-    "num_immunizations",
-    "num_devices",
-]
+TARGET_DEFAULT = KW_IND.TARGET_DEFAULT
+DEFAULT_BINS = KW_IND.DEFAULT_BINS
+METRICS_DEFAULT = KW_IND.METRICS_DEFAULT
 
-DEFAULT_P_NORM = "arctan"   # 'arctan' / 'exp' / 'log1p'
-DEFAULT_P_SCALE = 10.0
-DEFAULT_P_CAP = 300.0
+DEFAULT_P_NORM = KW_IND.DEFAULT_P_NORM # 'arctan' / 'exp' / 'log1p'
+DEFAULT_P_SCALE = KW_IND.DEFAULT_P_SCALE
+DEFAULT_P_CAP = KW_IND.DEFAULT_P_CAP
 
-# ==== ヘルパ（KW_IND.py 相当） ====
-
-def find_col_case_insensitive(df: pd.DataFrame, name: str) -> str | None:
-    low = name.lower()
-    for c in df.columns:
-        if c.lower() == low:
-            return c
-    return None
-
-def make_age_groups_by_custom_bins(age_series: pd.Series, custom_bins: list[float]) -> pd.Series:
-    age = pd.to_numeric(age_series, errors="coerce")
-    bins = np.array(sorted(custom_bins), dtype=float)
-    if len(bins) < 3:
-        raise ValueError("--custom-bins は 3 個以上の境界が必要です（>=2 群）。")
-    labels = []
-    for i in range(len(bins) - 1):
-        a, b = bins[i], bins[i + 1]
-        labels.append(f"{int(a)}+" if i == len(bins) - 2 else f"{int(a)}–{int(b)-1}")
-    finite_max = np.nanmax(age.values) if np.isfinite(np.nanmax(age.values)) else bins[-1]
-    extended = bins.copy()
-    extended[-1] = max(bins[-1], finite_max) + 1e-9
-    return pd.cut(age, bins=extended, right=False, labels=labels, include_lowest=True)
-
-def chi2_logp_safe(H: float, dfree: int) -> tuple[float, str]:
-    logp = chi2.logsf(H, dfree)
-    if np.isfinite(logp):
-        mlog10p = -logp / np.log(10.0)
-        p_str = f"1e-{mlog10p:.1f}" if mlog10p > 300 else f"{np.exp(logp):.3e}"
-        return float(mlog10p), p_str
-
-    v = float(dfree)
-    w = (H / v) ** (1.0 / 3.0)
-    mu = 1.0 - 2.0 / (9.0 * v)
-    sigma = np.sqrt(2.0 / (9.0 * v))
-    Z = (w - mu) / sigma
-    logp_norm = norm.logsf(abs(Z)) + np.log(2.0)
-    if np.isfinite(logp_norm):
-        mlog10p = -logp_norm / np.log(10.0)
-        p_str = f"1e-{mlog10p:.1f}" if mlog10p > 300 else f"{np.exp(logp_norm):.3e}"
-        return float(mlog10p), p_str
-
-    Z = abs(Z)
-    mlog10p = (Z * Z) / (2.0 * np.log(10.0)) + (np.log(Z) + 0.5 * np.log(2.0 * np.pi)) / np.log(10.0)
-    p_str = f"1e-{mlog10p:.1f}"
-    return float(mlog10p), p_str
-
-def eta2_kw(H: float, n_eff: int, k_used: int) -> float:
-    if n_eff <= 1:
-        return 0.0
-    val = (H - (k_used - 1.0)) / (n_eff - 1.0)
-    return float(np.clip(val, 0.0, 1.0))
-
-def rank_eta2(y: np.ndarray, g_codes: np.ndarray, G: int) -> float:
-    ranks = pd.Series(y).rank(method="average").to_numpy()
-    ybar = ranks.mean()
-    ssb = 0.0
-    for c in range(G):
-        mask = (g_codes == c)
-        if mask.any():
-            n_c = mask.sum()
-            m_c = ranks[mask].mean()
-            ssb += n_c * (m_c - ybar) ** 2
-    sst = ((ranks - ybar) ** 2).sum()
-    return float(ssb / sst) if sst > 0 else 0.0
-
-def vargha_delaney_A(x: np.ndarray, y: np.ndarray) -> float:
-    s = np.concatenate([x, y])
-    r = pd.Series(s).rank(method="average").to_numpy()
-    n1 = len(x)
-    r1 = r[:n1].sum()
-    A = (r1 - n1 * (n1 + 1) / 2.0) / (n1 * len(y))
-    return float(np.clip(A, 0.0, 1.0))
-
-def multi_group_A_metrics(groups: list[np.ndarray]) -> tuple[float, float]:
-    A_sum = 0.0
-    Asym_sum = 0.0
-    w_sum = 0.0
-    for i in range(len(groups)):
-        for j in range(i + 1, len(groups)):
-            xi, xj = groups[i], groups[j]
-            if len(xi) == 0 or len(xj) == 0:
-                continue
-            A = vargha_delaney_A(xi, xj)
-            w = len(xi) * len(xj)
-            A_sum += w * A
-            Asym_sum += w * (2.0 * abs(A - 0.5))
-            w_sum += w
-    if w_sum == 0:
-        return 0.5, 0.0
-    return float(A_sum / w_sum), float(Asym_sum / w_sum)
-
-def h_max_no_ties(counts: list[int] | np.ndarray) -> float:
-    c = np.asarray(counts, dtype=float)
-    n = c.sum()
-    if n <= 1 or (c <= 0).any():
-        return 0.0
-    prefix = np.concatenate(([0.0], np.cumsum(c[:-1])))
-    Rbar = prefix + (c + 1.0) / 2.0
-    overall = (n + 1.0) / 2.0
-    ssb = np.sum(c * (Rbar - overall) ** 2)
-    Hmax = (12.0 / (n * (n + 1.0))) * ssb
-    return float(max(Hmax, 0.0))
-
-def normalize_mlog10p(x, method=DEFAULT_P_NORM, scale=DEFAULT_P_SCALE, cap=DEFAULT_P_CAP):
-    x = np.asarray(x, dtype=float)
-    x = np.where(np.isfinite(x) & (x >= 0), x, 0.0)
-    if method == "arctan":
-        return (2.0 / np.pi) * np.arctan(x / float(scale))
-    elif method == "exp":
-        return 1.0 - np.exp(-x / float(scale))
-    else:  # "log1p"
-        cap = float(cap)
-        return np.log1p(np.minimum(x, cap)) / np.log1p(cap)
-
-# ==== 1つのCSVに対して KW 指標を算出 ====
-
-NUM_COLS = ["H_norm", "minus_log10_p_norm", "epsilon2", "eta2_kw", "rank_eta2", "A_pair_avg", "A_pair_sym"]
-
-def compute_kw_table(csv_path: str,
-                     age_col_name: str,
-                     metrics_csv: str,
-                     custom_bins_str: str,
-                     min_per_group: int,
-                     p_norm: str, p_scale: float, p_cap: float) -> pd.DataFrame:
-    df = pd.read_csv(csv_path, dtype=str, keep_default_na=False)
-
-    age_col = find_col_case_insensitive(df, age_col_name)
-    if age_col is None:
-        raise SystemExit(f"[{csv_path}] 年齢列 {age_col_name} が見つかりません。")
-
-    metric_names = [m.strip() for m in metrics_csv.split(",") if m.strip()]
-    metrics, not_found = [], []
-    for m in metric_names:
-        col = find_col_case_insensitive(df, m)
-        (metrics if col is not None else not_found).append(col or m)
-
-    if not metrics:
-        # どれも無ければ空表（あとで0埋め差分可）
-        return pd.DataFrame(columns=["metric"] + NUM_COLS)
-
-    custom_bins = DEFAULT_BINS if not custom_bins_str.strip() else [float(x) for x in custom_bins_str.split(",") if x.strip()]
-    groups_ser = make_age_groups_by_custom_bins(df[age_col], custom_bins)
-
-    rows = []
-    for m in metrics:
-        if m not in df.columns:
-            # 無い metric は0埋め（差分用）
-            rows.append({"metric": m, **{k: 0.0 for k in NUM_COLS}})
-            continue
-
-        y_all = pd.to_numeric(df[m], errors="coerce")
-        mask = y_all.notna() & groups_ser.notna()
-        y = y_all[mask].to_numpy(dtype=float)
-        g = pd.Categorical(groups_ser[mask])
-        labels = list(g.categories.astype(str))
-        k = len(labels)
-
-        # 各群
-        grp_vals = [y[g.codes == i] for i in range(k)]
-        used_vals = [arr for arr in grp_vals if len(arr) >= min_per_group]
-        n_eff = sum(len(arr) for arr in used_vals)
-        k_used = len(used_vals)
-
-        if k_used < 2:
-            rows.append({"metric": m, **{k: 0.0 for k in NUM_COLS}})
-            continue
-
-        # Kruskal–Wallis
-        try:
-            H, _ = kruskal(*used_vals)
-        except Exception:
-            rows.append({"metric": m, **{k: 0.0 for k in NUM_COLS}})
-            continue
-
-        dfree = k_used - 1
-        mlog10p, _ = chi2_logp_safe(float(H), dfree)
-
-        # 効果量
-        eps = (H - dfree) / (n_eff - dfree) if (n_eff - dfree) > 0 else 0.0
-        eps = float(np.clip(eps, 0.0, 1.0))
-        eta = eta2_kw(float(H), int(n_eff), int(k_used))
-        g_codes = np.concatenate([np.full(len(arr), i, dtype=int) for i, arr in enumerate(used_vals)])
-        r_eta = rank_eta2(y=np.concatenate(used_vals), g_codes=g_codes, G=k_used)
-        A_avg, A_sym = multi_group_A_metrics(used_vals)
-
-        # H の 0-1 正規化（H/Hmax）
-        Hmax = h_max_no_ties([len(arr) for arr in used_vals])
-        H_scaled_max = float(H / Hmax) if Hmax > 0 else 0.0
-        H_scaled_max = float(np.clip(H_scaled_max, 0.0, 1.0))
-
-        # minus_log10_p の 0-1 正規化（飽和しにくい）
-        pnorm = float(normalize_mlog10p(mlog10p, method=p_norm, scale=p_scale, cap=p_cap))
-
-        rows.append({
-            "metric": m,
-            "H_norm": H_scaled_max,
-            "minus_log10_p_norm": pnorm,
-            "epsilon2": eps,
-            "eta2_kw": eta,
-            "rank_eta2": float(r_eta),
-            "A_pair_avg": A_avg,
-            "A_pair_sym": A_sym
-        })
-
-    out = pd.DataFrame(rows, columns=["metric"] + NUM_COLS)
-    # 欠損は0埋め
-    for c in NUM_COLS:
-        out[c] = pd.to_numeric(out[c], errors="coerce").fillna(0.0)
-    out = out.sort_values("metric", kind="mergesort").reset_index(drop=True)
-    return out
+NUM_COLS = KW_IND.NUM_COLS
 
 
-def main():
+def eval(path_to_csv1:str, path_to_csv2:str,
+         age_col=TARGET_DEFAULT, metrics=",".join(METRICS_DEFAULT),
+         custom_bins="", min_per_group=2, 
+         p_norm=DEFAULT_P_NORM, p_scale=DEFAULT_P_SCALE, 
+         p_cap=DEFAULT_P_CAP, out=None, print_details=False) -> float:
+    """
+    CSVファイルへのパスを2つ受け取って、それらのKW指標のうち最も大きい差を返す
+
+    Paramters:
+    path_to_csv1 (str): CSVファイルその1
+    path_to_csv2 (str): CSVファイルその2
+    out (str): 各指標の差を保存したい場所を指定。テーブル同士の差が書き込まれる
+    print_details (bool): 詳細の結果を表示するかどうか
+
+    Returns:
+    最も大きいKW指標の差 (float)
+    """
+    
+    # csvファイルをpandasのDataFrameとして読み込み
+    df1 = pd.read_csv(path_to_csv1, dtype=str, keep_default_na=False)
+    df2 = pd.read_csv(path_to_csv2, dtype=str, keep_default_na=False)
+
+    max_abs = eval_diff_max_abs(df1, df2, age_col, metrics,
+         custom_bins, min_per_group, p_norm, p_scale, p_cap, 
+         out, print_details)
+
+    return max_abs
+
+def eval_diff_max_abs(df1: pd.DataFrame, df2:pd.DataFrame, 
+                      age_col=TARGET_DEFAULT, 
+                      metrics=",".join(METRICS_DEFAULT),
+                      custom_bins="", min_per_group=2, 
+                      p_norm=DEFAULT_P_NORM, p_scale=DEFAULT_P_SCALE, 
+                      p_cap=DEFAULT_P_CAP,
+                      out=None, print_details=False) -> float:
+    """
+    データフレームを2つ受け取って、最も大きいKW指標の差を返す
+
+    Paramters:
+    df1 (pd.DataFrame): データフレームその1
+    df2 (pd.DataFrame): データフレームその2
+    out (str): 各指標の差を保存したい場所を指定。各指標の差が書き込まれる
+    print_details (bool): 詳細の結果を表示するかどうか
+
+    Returns:
+    最も大きいKW指標の差 (float)
+    """
+
+    diff = eval_diff(df1, df2, age_col, metrics,
+         custom_bins, min_per_group, p_norm, p_scale, p_cap, 
+         out, print_details)
+
+
+    # 全差分の最大絶対値
+    max_abs = float(np.nanmax(np.abs(diff[NUM_COLS].to_numpy()))) if not diff.empty else 0.0
+
+    return max_abs
+
+def eval_diff(df1: pd.DataFrame, df2:pd.DataFrame, 
+                      age_col=TARGET_DEFAULT, 
+                      metrics=",".join(METRICS_DEFAULT),
+                      custom_bins="", min_per_group=2, 
+                      p_norm=DEFAULT_P_NORM, p_scale=DEFAULT_P_SCALE, 
+                      p_cap=DEFAULT_P_CAP,
+                      out=None, print_details=False) -> pd.DataFrame:
+    """
+    データフレームを2つ受け取って、各指標の差を計算する
+
+    Paramters:
+    df1 (pd.DataFrame): データフレームその1
+    df2 (pd.DataFrame): データフレームその2
+    out (str): 各指標の差を保存したい場所を指定。各指標の差が書き込まれる
+    print_details (bool): 詳細の結果を表示するかどうか
+
+    Returns:
+    テーブルその2の指標 - テーブルその1の指標 (pd.DataFrame)
+    """
+    # DataFrameからKW指標をまとめたテーブルを算出
+    kw_table1 = KW_IND.compute_kw_table(
+        df1, age_col, metrics, custom_bins,
+        min_per_group, p_norm, p_scale, p_cap
+    )
+    kw_table2 = KW_IND.compute_kw_table(
+        df2, age_col, metrics, custom_bins,
+        min_per_group, p_norm, p_scale, p_cap
+    )
+
+    # metric の和集合で揃え、欠側は0埋め
+    metrics_all = sorted(set(kw_table1["metric"]).union(set(kw_table2["metric"])))
+    t1i = kw_table1.set_index("metric").reindex(metrics_all).fillna(0.0)
+    t2i = kw_table2.set_index("metric").reindex(metrics_all).fillna(0.0)
+
+    # 差分 (file2 - file1)
+    diff = (t2i[NUM_COLS] - t1i[NUM_COLS]).reset_index()
+    diff = diff.rename(columns={"index": "metric"}).sort_values("metric", kind="mergesort").reset_index(drop=True)
+
+    # 表示（KW_IND 風ヘッダ、group_sizes なし）
+    if print_details:
+        with pd.option_context("display.max_columns", None,
+                               "display.width", None,
+                               "display.float_format", lambda x: f"{x:.6g}"):
+            print("\n=== KW_IND Diff (file2 - file1) — H_norm / p_norm / effect sizes (0–1) ===")
+            print(diff.to_string(index=False))
+
+    # 保存オプション
+    if out:
+        diff.to_csv(out, index=False)
+
+    return diff
+
+if __name__ == "__main__":
     ap = argparse.ArgumentParser(description="KW_IND 差分: 2つのCSVの 0～1 指標を (file2 - file1) で出力し、最後に最大絶対差を表示（group_sizes非表示）。")
     ap.add_argument("csv1", help="1つ目のCSV（baseline）")
     ap.add_argument("csv2", help="2つ目のCSV（to compare）")
@@ -263,38 +165,9 @@ def main():
     ap.add_argument("-o", "--out", default=None, help="差分テーブルをCSV保存するパス（任意）")
     args = ap.parse_args()
 
-    t1 = compute_kw_table(
-        args.csv1, args.age_col, args.metrics, args.custom_bins,
-        args.min_per_group, args.p_norm, args.p_scale, args.p_cap
-    )
-    t2 = compute_kw_table(
-        args.csv2, args.age_col, args.metrics, args.custom_bins,
-        args.min_per_group, args.p_norm, args.p_scale, args.p_cap
-    )
-
-    # metric の和集合で揃え、欠側は0埋め
-    metrics_all = sorted(set(t1["metric"]).union(set(t2["metric"])))
-    t1i = t1.set_index("metric").reindex(metrics_all).fillna(0.0)
-    t2i = t2.set_index("metric").reindex(metrics_all).fillna(0.0)
-
-    # 差分 (file2 - file1)
-    diff = (t2i[NUM_COLS] - t1i[NUM_COLS]).reset_index()
-    diff = diff.rename(columns={"index": "metric"}).sort_values("metric", kind="mergesort").reset_index(drop=True)
-
-    # 表示（KW_IND 風ヘッダ、group_sizes なし）
-    with pd.option_context("display.max_columns", None,
-                           "display.width", None,
-                           "display.float_format", lambda x: f"{x:.6g}"):
-        print("\n=== KW_IND Diff (file2 - file1) — H_norm / p_norm / effect sizes (0–1) ===")
-        print(diff.to_string(index=False))
-
-    # 全差分の最大絶対値
-    max_abs = float(np.nanmax(np.abs(diff[NUM_COLS].to_numpy()))) if not diff.empty else 0.0
+    # 2つのKWテーブルの差を評価
+    max_abs = eval(args.csv1, args.csv2, args.age_col, args.metrics,
+                   args.custom_bins, args.min_per_group, 
+                   args.p_norm, args.p_scale, args.p_cap,
+                   args.out, True)
     print(f"\nMAX_ABS_DIFF {max_abs:.6g}")
-
-    # 保存オプション
-    if args.out:
-        diff.to_csv(args.out, index=False)
-
-if __name__ == "__main__":
-    main()

--- a/evaluation/LR_asthma_diff.py
+++ b/evaluation/LR_asthma_diff.py
@@ -15,186 +15,66 @@ LR_asthma_diff.py
 """
 
 import argparse
+import sys
+import os
+
 import numpy as np
 import pandas as pd
-import statsmodels.api as sm
-from sklearn.metrics import roc_auc_score
-from sklearn.model_selection import train_test_split
-from statsmodels.stats.outliers_influence import variance_inflation_factor
+
+# モジュールの相対参照制限を強制的に回避
+current_dir = os.path.dirname(os.path.abspath(__file__))
+sys.path.append(os.path.join(current_dir, '..', 'analysis'))
+import LR_asthma
 
 
-# ==== ユーティリティ（LR_asthma.py と整合） ====
+COLS_ORDER = LR_asthma.COLS_ORDER
 
-def is_binary_01(s: pd.Series) -> bool:
-    if s.empty:
-        return False
-    ss = s.astype(str).str.strip()
-    ss = ss[~ss.str.lower().isin({"nan", "none", ""})]
-    if ss.empty:
-        return False
-    num = pd.to_numeric(ss, errors="coerce")
-    if num.isna().any():
-        return False
-    vals = set(pd.unique(num.dropna().astype(int)))
-    return vals.issubset({0, 1}) and len(vals) > 0
-
-def odds_to_unit(x):
-    arr = np.asarray(x, dtype=float)
-    return arr / (1.0 + arr)
-
-def vif_to_unit(v):
-    v = np.asarray(v, dtype=float)
-    v = np.where(~np.isfinite(v) | (v < 1.0), 1.0, v)
-    return 1.0 - 1.0 / v
-
-
-# ==== 1 CSV から LR_asthma 互換の表を作る ====
-
-COLS_ORDER = ["term", "coef", "p_value", "OR_norm", "CI_low_norm", "CI_high_norm", "VIF_norm"]
-
-def run_lr_table(csv_path: str,
-                 target: str = "asthma_flag",
-                 test_size: float = 0.2,
-                 random_state: int = 42,
-                 ensure_terms: str = "ETHNICITY_hispanic") -> tuple[pd.DataFrame, float, list[str]]:
+def eval_diff_max_abs(df1: pd.DataFrame, df2: pd.DataFrame, 
+              target="asthma_flag", test_size=0.2, random_state=42, ensure_terms="ETHNICITY_hispanic",
+              out=None, print_details=False):
     """
-    csv_path を読み、LR_asthma.py と同様に
-    - 前処理（数値 + カテゴリone-hot drop_first）
-    - ロジスティック回帰（const あり、出力は const 除外）
-    - OR/CI を 0-1 化、VIF を 0-1 化
-    - 固定順序の term を作る（方式B: 学習に使った列 ∪ ensure_terms を辞書順）
-    を行い、[COLS_ORDER] の表を返す。AUC と最終の term リストも返す。
+    DataFrameを2つ受け取って、それらのLRでの差が最大になる変数での差を出力
+
+    Paramters:
+    path_to_csv1 (str): CSVファイルその1
+    path_to_csv2 (str): CSVファイルその1
+    out (str): 各指標の差を保存したい場所を指定。テーブル同士の差が書き込まれる
+    print_details (bool): 詳細の結果を表示するかどうか
+
+    Returns:
+    最も大きい差 (float)
     """
-    df = pd.read_csv(csv_path, dtype=str, keep_default_na=False)
 
-    if target not in df.columns:
-        raise SystemExit(f"[{csv_path}] target column '{target}' not found.")
-    if not is_binary_01(df[target]):
-        raise SystemExit(f"[{csv_path}] target column '{target}' must be strictly binary 0/1.")
+    diff = eval_diff(df1, df2, target, test_size, random_state, ensure_terms, out, print_details)
 
-    y = pd.to_numeric(df[target], errors="coerce").astype("float64")
+    # 最大絶対差（表の全数値列から算出。AUCは含めない）
+    max_abs = float(np.nanmax(np.abs(diff[COLS_ORDER[1:]].to_numpy()))) if not diff.empty else 0.0
 
-    X_raw = df.drop(columns=[target]).copy()
-    X_num_try = X_raw.apply(pd.to_numeric, errors="coerce")
-    num_cols = [c for c in X_num_try.columns if X_num_try[c].notna().sum() > 0]
-    X_num = X_num_try[num_cols] if num_cols else pd.DataFrame(index=df.index)
+    return max_abs
 
-    cat_cols = [c for c in X_raw.columns if c not in num_cols]
-    if cat_cols:
-        X_cat = pd.get_dummies(
-            X_raw[cat_cols].replace({"": np.nan}).fillna("(NA)").astype("category"),
-            drop_first=True
-        )
-    else:
-        X_cat = pd.DataFrame(index=df.index)
+def eval_diff(df1: pd.DataFrame, df2: pd.DataFrame, 
+              target="asthma_flag", test_size=0.2, random_state=42, ensure_terms="ETHNICITY_hispanic",
+              out=None, print_details=False):
+    """
+    DataFrameを2つ受け取って、それぞれの各変数を目的としたLRを実行して、差を評価
 
-    X = pd.concat([X_num, X_cat], axis=1)
-    X = X.apply(pd.to_numeric, errors="coerce").replace([np.inf, -np.inf], np.nan)
-    X = X.dropna(axis=1, how="all")
-    if X.shape[1] == 0:
-        raise SystemExit(f"[{csv_path}] No usable features after preprocessing.")
+    Paramters:
+    kw_table1 (pd.DataFrame): DataFrameその1
+    kw_table2 (pd.DataFrame): DataFrameその2
+    out (str): 各差を保存したい場所を指定。テーブル同士の差が書き込まれる
+    print_details (bool): 詳細の結果を表示するかどうか
 
-    med = X.median(numeric_only=True)
-    X = X.fillna(med).astype("float64")
-    zero_var = X.nunique(dropna=False) <= 1
-    if zero_var.all():
-        raise SystemExit(f"[{csv_path}] All feature columns have zero variance.")
-    if zero_var.any():
-        X = X.loc[:, ~zero_var]
-
-    base_terms = sorted(X.columns.tolist())
-    X = X.reindex(columns=base_terms)
-
-    mask = y.notna() & y.isin([0.0, 1.0])
-    X = X.loc[mask]
-    y = y.loc[mask]
-    if X.shape[0] < 3 or X.shape[1] == 0:
-        raise SystemExit(f"[{csv_path}] Not enough samples or features after cleaning.")
-
-    X_tr, X_te, y_tr, y_te = train_test_split(
-        X, y, test_size=test_size, random_state=random_state, stratify=y.astype(int)
-    )
-    X_tr_const = sm.add_constant(X_tr, has_constant="add").astype("float64")
-    X_te_const = sm.add_constant(X_te, has_constant="add").astype("float64")
-
-    model = sm.GLM(y_tr.astype("float64"), X_tr_const, family=sm.families.Binomial())
-    res = model.fit()
-
-    proba = res.predict(X_te_const)
-    auc = roc_auc_score(y_te, proba)
-
-    params = res.params.drop(labels=["const"])
-    pvals  = res.pvalues.drop(labels=["const"])
-    conf   = res.conf_int().drop(index="const")  # columns [0,1]
-
-    OR      = np.exp(params.values)
-    CI_low  = np.exp(conf[0].reindex(params.index).values)
-    CI_high = np.exp(conf[1].reindex(params.index).values)
-
-    coef_df = pd.DataFrame({
-        "term": params.index,
-        "coef": params.values,
-        "p_value": pvals.values,
-        "OR_norm": odds_to_unit(OR),
-        "CI_low_norm": odds_to_unit(CI_low),
-        "CI_high_norm": odds_to_unit(CI_high),
-    })
-
-    # VIF（const除外）
-    vif_rows = []
-    cols = list(X_tr_const.columns)  # ['const', ...base_terms...]
-    for i, col in enumerate(cols):
-        if col == "const":
-            continue
-        try:
-            v = float(variance_inflation_factor(X_tr_const.values, i))
-        except Exception:
-            v = np.nan
-        vif_rows.append((col, v))
-    vif_df = pd.DataFrame(vif_rows, columns=["term", "VIF"])
-    vif_df["VIF_norm"] = vif_to_unit(vif_df["VIF"].values)
-    vif_df = vif_df.drop(columns=["VIF"])
-
-    # 固定スキーマ：ensure-terms を union
-    ensure_list = [t.strip() for t in ensure_terms.split(",") if t.strip()]
-    final_terms = sorted(set(base_terms).union(ensure_list))
-
-    out = (coef_df.merge(vif_df, on="term", how="outer")
-                  .set_index("term")
-                  .reindex(final_terms)
-                  .reset_index())
-
-    # 欠損は 0 に
-    for c in COLS_ORDER[1:]:
-        out[c] = pd.to_numeric(out[c], errors="coerce").fillna(0.0)
-
-    # 列順
-    out = out[COLS_ORDER]
-    return out, float(auc), final_terms
-
-
-# ==== 差分本体 ====
-
-def main():
-    ap = argparse.ArgumentParser(description="LR_asthma 差分: 2つのCSVの 0〜1 指標（coefは実数）を (file2 - file1) で出力。欠側termは0埋め。NaNは0。")
-    ap.add_argument("csv1", help="1つ目のCSV（baseline）")
-    ap.add_argument("csv2", help="2つ目のCSV（to compare）")
-    ap.add_argument("--target", default="asthma_flag", help="binary target column (default: asthma_flag)")
-    ap.add_argument("--test-size", type=float, default=0.2, help="holdout ratio (default: 0.2)")
-    ap.add_argument("--random-state", type=int, default=42, help="random seed (default: 42)")
-    ap.add_argument("--ensure-terms", default="ETHNICITY_hispanic",
-                    help="常に出力に含めたい term 名（カンマ区切り）")
-    ap.add_argument("-o", "--out", default=None, help="差分表をCSV保存（任意）")
-    args = ap.parse_args()
-
+    Returns:
+    その2 - その1 (pd.DataFrame)
+    """
     # 片方ずつ LR 実行
-    t1, auc1, terms1 = run_lr_table(
-        args.csv1, target=args.target, test_size=args.test_size,
-        random_state=args.random_state, ensure_terms=args.ensure_terms
+    t1, auc1, terms1 = LR_asthma.run_lr_table(
+        df1, target=target, test_size=test_size,
+        random_state=random_state, ensure_terms=ensure_terms
     )
-    t2, auc2, terms2 = run_lr_table(
-        args.csv2, target=args.target, test_size=args.test_size,
-        random_state=args.random_state, ensure_terms=args.ensure_terms
+    t2, auc2, terms2 = LR_asthma.run_lr_table(
+        df2, target=target, test_size=test_size,
+        random_state=random_state, ensure_terms=ensure_terms
     )
 
     # term 和集合で reindex（欠側は0）
@@ -211,23 +91,59 @@ def main():
         diff[c] = pd.to_numeric(diff[c], errors="coerce").fillna(0.0)
 
     # 出力
-    with pd.option_context("display.max_columns", None,
-                           "display.width", None,
-                           "display.float_format", lambda x: f"{x:.6g}"):
-        print(f"AUC (file1): {auc1:.6f}")
-        print(f"AUC (file2): {auc2:.6f}")
-        print(f"AUC_DIFF   : {auc2 - auc1:.6f}")
+    if print_details:
+        with pd.option_context("display.max_columns", None,
+                               "display.width", None,
+                               "display.float_format", lambda x: f"{x:.6g}"):
+            print(f"AUC (file1): {auc1:.6f}")
+            print(f"AUC (file2): {auc2:.6f}")
+            print(f"AUC_DIFF   : {auc2 - auc1:.6f}")
 
-        print("\n=== Logistic regression DIFF (file2 - file1) — const excluded; values are differences ===")
-        print(diff.to_string(index=False))
-
-    # 最大絶対差（表の全数値列から算出。AUCは含めない）
-    max_abs = float(np.nanmax(np.abs(diff[COLS_ORDER[1:]].to_numpy()))) if not diff.empty else 0.0
-    print(f"\nMAX_ABS_DIFF {max_abs:.6g}")
+            print("\n=== Logistic regression DIFF (file2 - file1) — const excluded; values are differences ===")
+            print(diff.to_string(index=False))
 
     # 保存（任意）
-    if args.out:
-        diff.to_csv(args.out, index=False)
+    if out:
+        diff.to_csv(out, index=False)
+
+    return diff
+
+def eval(path_to_csv1:str, path_to_csv2:str,
+         target="asthma_flag", test_size=0.2, random_state=42, ensure_terms="ETHNICITY_hispanic",
+         out=None, print_details=False):
+    """
+    CSVファイルへのパスを2つ受け取って、それらのLRでの差が最大になる変数での差を出力
+
+    Paramters:
+    path_to_csv1 (str): CSVファイルその1
+    path_to_csv2 (str): CSVファイルその2
+    out (str): 各指標の差を保存したい場所を指定。テーブル同士の差が書き込まれる
+    print_details (bool): 詳細の結果を表示するかどうか
+
+    Returns:
+    最も大きい差 (float)
+    """
+    
+    df1 = pd.read_csv(path_to_csv1, dtype=str, keep_default_na=False)
+    df2 = pd.read_csv(path_to_csv2, dtype=str, keep_default_na=False)
+
+    max_abs = eval_diff_max_abs(df1, df2, target, test_size, random_state, ensure_terms, out, print_details)
+
+    return max_abs
 
 if __name__ == "__main__":
-    main()
+    ap = argparse.ArgumentParser(description="LR_asthma 差分: 2つのCSVの 0〜1 指標（coefは実数）を (file2 - file1) で出力。欠側termは0埋め。NaNは0。")
+    ap.add_argument("csv1", help="1つ目のCSV（baseline）")
+    ap.add_argument("csv2", help="2つ目のCSV（to compare）")
+    ap.add_argument("--target", default="asthma_flag", help="binary target column (default: asthma_flag)")
+    ap.add_argument("--test-size", type=float, default=0.2, help="holdout ratio (default: 0.2)")
+    ap.add_argument("--random-state", type=int, default=42, help="random seed (default: 42)")
+    ap.add_argument("--ensure-terms", default="ETHNICITY_hispanic",
+                    help="常に出力に含めたい term 名（カンマ区切り）")
+    ap.add_argument("-o", "--out", default=None, help="差分表をCSV保存（任意）")
+    args = ap.parse_args()
+
+    max_abs = eval(args.csv1, args.csv2, 
+                   args.target, args.test_size, args.random_state, 
+                   args.ensure_terms, args.out, True)
+    print(f"\nMAX_ABS_DIFF {max_abs:.6g}")


### PR DESCRIPTION
evaluation内のモジュール(e.g., KW_IND_diff.py)の一部にanalysis内のモジュール(e.g., KW_IND.py)と全く同じ関数を持つものがあったので、evalutionの方からは削除して、analysisのものを呼び出すように改変。同じ関数が複数箇所に書かれているとバグが見つかった時に直したつもりで直っていないことがあるので、それを防いで保守性を高める意図。

また、 KW_IND_diff.py, LR_asthma_diff.py, stats_diff.pyの`if __name__="__main__":`のブロックの関数の呼び出し方を変更。ここではevalという関数にコマンドライン引数を引き渡すだけにし、evalの中で計算を行う。さらに、evalもcsvの読み込み、絶対誤差の計算、各差の計算、と処理の段階で分割。参加者が一部の機能だけを引っこ抜いて開発ができる設計に。